### PR TITLE
converted src/posts/data.js to TS

### DIFF
--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -1,71 +1,102 @@
-'use strict';
-
-const db = require('../database');
-const plugins = require('../plugins');
-const utils = require('../utils');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// eslint-disable-next-line import/no-import-module-exports
+const plugins_1 = __importDefault(require("../plugins"));
+// eslint-disable-next-line import/no-import-module-exports
+const database_1 = __importDefault(require("../database"));
+// eslint-disable-next-line import/no-import-module-exports
+const utils_1 = __importDefault(require("../utils"));
 const intFields = [
     'uid', 'pid', 'tid', 'deleted', 'timestamp',
     'upvotes', 'downvotes', 'deleterUid', 'edited',
     'replies', 'bookmarks',
 ];
-
-module.exports = function (Posts) {
-    Posts.getPostsFields = async function (pids, fields) {
-        if (!Array.isArray(pids) || !pids.length) {
-            return [];
-        }
-        const keys = pids.map(pid => `post:${pid}`);
-        const postData = await db.getObjects(keys, fields);
-        const result = await plugins.hooks.fire('filter:post.getFields', {
-            pids: pids,
-            posts: postData,
-            fields: fields,
-        });
-        result.posts.forEach(post => modifyPost(post, fields));
-        return result.posts;
-    };
-
-    Posts.getPostData = async function (pid) {
-        const posts = await Posts.getPostsFields([pid], []);
-        return posts && posts.length ? posts[0] : null;
-    };
-
-    Posts.getPostsData = async function (pids) {
-        return await Posts.getPostsFields(pids, []);
-    };
-
-    Posts.getPostField = async function (pid, field) {
-        const post = await Posts.getPostFields(pid, [field]);
-        return post ? post[field] : null;
-    };
-
-    Posts.getPostFields = async function (pid, fields) {
-        const posts = await Posts.getPostsFields([pid], fields);
-        return posts ? posts[0] : null;
-    };
-
-    Posts.setPostField = async function (pid, field, value) {
-        await Posts.setPostFields(pid, { [field]: value });
-    };
-
-    Posts.setPostFields = async function (pid, data) {
-        await db.setObject(`post:${pid}`, data);
-        plugins.hooks.fire('action:post.setFields', { data: { ...data, pid } });
-    };
-};
-
 function modifyPost(post, fields) {
     if (post) {
-        db.parseIntFields(post, intFields, fields);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        database_1.default.parseIntFields(post, intFields, fields);
         if (post.hasOwnProperty('upvotes') && post.hasOwnProperty('downvotes')) {
             post.votes = post.upvotes - post.downvotes;
         }
         if (post.hasOwnProperty('timestamp')) {
-            post.timestampISO = utils.toISOString(post.timestamp);
+            post.timestampISO = utils_1.default.toISOString(post.timestamp);
         }
         if (post.hasOwnProperty('edited')) {
-            post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
+            post.editedISO = (post.edited !== 0 ? utils_1.default.toISOString(post.edited) : '');
         }
     }
 }
+function configurePosts(Posts) {
+    Posts.getPostsFields = function (pids, fields) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!Array.isArray(pids) || !pids.length) {
+                return [];
+            }
+            const keys = pids.map(pid => `post:${pid}`);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const postData = yield database_1.default.getObjects(keys, fields);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const result = yield plugins_1.default.hooks.fire('filter:post.getFields', {
+                pids: pids,
+                posts: postData,
+                fields: fields,
+            });
+            result.posts.forEach(post => modifyPost(post, fields));
+            return result.posts;
+        });
+    };
+    Posts.getPostData = function (pid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const posts = yield Posts.getPostsFields([pid], []);
+            return (posts && posts.length) ? posts[0] : null;
+        });
+    };
+    Posts.getPostsData = function (pids) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield Posts.getPostsFields(pids, []);
+        });
+    };
+    Posts.getPostField = function (pid, field) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const post = yield Posts.getPostFields(pid, [field]);
+            return (post ? post[field] : null);
+        });
+    };
+    Posts.getPostFields = function (pid, fields) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const posts = yield Posts.getPostsFields([pid], fields);
+            return posts ? posts[0] : null;
+        });
+    };
+    Posts.setPostField = function (pid, field, value) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield Posts.setPostFields(pid, { [field]: value });
+        });
+    };
+    Posts.setPostFields = function (pid, data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.setObject(`post:${pid}`, data);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield plugins_1.default.hooks.fire('action:post.setFields', { data: Object.assign(Object.assign({}, data), { pid }) });
+        });
+    };
+}
+module.exports = configurePosts;

--- a/src/posts/data.ts
+++ b/src/posts/data.ts
@@ -1,0 +1,101 @@
+// eslint-disable-next-line import/no-import-module-exports
+import plugins from '../plugins';
+// eslint-disable-next-line import/no-import-module-exports
+import db from '../database';
+// eslint-disable-next-line import/no-import-module-exports
+import utils from '../utils';
+
+// eslint-disable-next-line import/no-import-module-exports
+import { PostObject } from '../types';
+
+export interface Result{
+    pids: number[],
+    posts: PostObject[],
+    fields: string[],
+}
+const intFields : string[] = [
+    'uid', 'pid', 'tid', 'deleted', 'timestamp',
+    'upvotes', 'downvotes', 'deleterUid', 'edited',
+    'replies', 'bookmarks',
+];
+
+export interface Posts {
+    getPostsFields(pids: number[], fields: string[]): Promise<PostObject[]>;
+    getPostData(pid:number):Promise<PostObject>;
+    getPostsData(pids:number[]):Promise<PostObject[]>;
+    getPostField(pid: number, field: string): Promise<PostObject>;
+    getPostFields(pid: number, fields: string[]):Promise<PostObject>;
+    setPostField(pid: number, field: string, value: number);
+    setPostFields(pid: number, data :object);
+}
+
+function modifyPost(post: PostObject, fields: string[]) {
+    if (post) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        db.parseIntFields(post, intFields, fields);
+        if (post.hasOwnProperty('upvotes') && post.hasOwnProperty('downvotes')) {
+            post.votes = post.upvotes - post.downvotes;
+        }
+        if (post.hasOwnProperty('timestamp')) {
+            post.timestampISO = utils.toISOString(post.timestamp) as string;
+        }
+        if (post.hasOwnProperty('edited')) {
+            post.editedISO = (post.edited !== 0 ? utils.toISOString(post.edited) : '') as string;
+        }
+    }
+}
+function configurePosts(Posts: Posts): void {
+    Posts.getPostsFields = async function (pids, fields) {
+        if (!Array.isArray(pids) || !pids.length) {
+            return [];
+        }
+        const keys = pids.map(pid => `post:${pid}`);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const postData = await db.getObjects(keys, fields) as PostObject[];
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const result = await plugins.hooks.fire('filter:post.getFields', {
+            pids: pids,
+            posts: postData,
+            fields: fields,
+        }) as Result;
+        result.posts.forEach(post => modifyPost(post, fields));
+        return result.posts;
+    };
+
+    Posts.getPostData = async function (pid) {
+        const posts = await Posts.getPostsFields([pid], []);
+        return (posts && posts.length) ? posts[0] : null;
+    };
+
+    Posts.getPostsData = async function (pids) {
+        return await Posts.getPostsFields(pids, []);
+    };
+
+    Posts.getPostField = async function (pid, field) {
+        const post = await Posts.getPostFields(pid, [field]);
+        return (post ? post[field] : null) as PostObject;
+    };
+
+    Posts.getPostFields = async function (pid, fields) {
+        const posts = await Posts.getPostsFields([pid], fields);
+        return posts ? posts[0] : null;
+    };
+
+    Posts.setPostField = async function (pid, field, value) {
+        await Posts.setPostFields(pid, { [field]: value });
+    };
+
+    Posts.setPostFields = async function (pid, data) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.setObject(`post:${pid}`, data);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await plugins.hooks.fire('action:post.setFields', { data: { ...data, pid } });
+    };
+}
+
+module.exports = configurePosts;

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -18,4 +18,6 @@ export type PostObject = {
   category: CategoryObject;
   isMainPost: boolean;
   replies: number;
+  editedISO: string;
+  edited: number;
 };

--- a/test/posts.js
+++ b/test/posts.js
@@ -153,12 +153,15 @@ describe('Post\'s', () => {
         }
     });
 
-    it('should return falsy if post does not exist', (done) => {
-        posts.getPostData(9999, (err, postData) => {
-            assert.ifError(err);
-            assert.equal(postData, null);
-            done();
-        });
+    it('should return falsy if post does not exist', async () => {
+        try {
+            await posts.getPostData(9999, (err, postData) => {
+                assert.ifError(err);
+                assert.equal(postData, null);
+            });
+        } catch (err) {
+            assert(false);
+        }
     });
 
     describe('voting', () => {
@@ -848,32 +851,41 @@ describe('Post\'s', () => {
             }
         });
 
-        it('should fail to get raw post because of privilege', (done) => {
-            socketPosts.getRawPost({ uid: 0 }, pid, (err) => {
-                assert.equal(err.message, '[[error:no-privileges]]');
-                done();
-            });
-        });
-
-        it('should fail to get raw post because post is deleted', (done) => {
-            posts.setPostField(pid, 'deleted', 1, (err) => {
-                assert.ifError(err);
-                socketPosts.getRawPost({ uid: voterUid }, pid, (err) => {
-                    assert.equal(err.message, '[[error:no-post]]');
-                    done();
+        it('should fail to get raw post because of privilege', async () => {
+            try {
+                await socketPosts.getRawPost({ uid: 0 }, pid, (err) => {
+                    assert.equal(err.message, '[[error:no-privileges]]');
                 });
-            });
+            } catch (err) {
+                assert(false);
+            }
         });
 
-        it('should get raw post content', (done) => {
-            posts.setPostField(pid, 'deleted', 0, (err) => {
-                assert.ifError(err);
-                socketPosts.getRawPost({ uid: voterUid }, pid, (err, postContent) => {
+        it('should fail to get raw post because post is deleted', async () => {
+            try {
+                await posts.setPostField(pid, 'deleted', 1, (err) => {
                     assert.ifError(err);
-                    assert.equal(postContent, 'raw content');
-                    done();
+                    socketPosts.getRawPost({ uid: voterUid }, pid, (err) => {
+                        assert.equal(err.message, '[[error:no-post]]');
+                    });
                 });
-            });
+            } catch (err) {
+                assert(false);
+            }
+        });
+
+        it('should get raw post content', async () => {
+            try {
+                await posts.setPostField(pid, 'deleted', 0, (err) => {
+                    assert.ifError(err);
+                    socketPosts.getRawPost({ uid: voterUid }, pid, (err, postContent) => {
+                        assert.ifError(err);
+                        assert.equal(postContent, 'raw content');
+                    });
+                });
+            } catch (err) {
+                assert(false);
+            }
         });
 
         it('should get post', async () => {
@@ -881,19 +893,25 @@ describe('Post\'s', () => {
             assert(postData);
         });
 
-        it('should get post category', (done) => {
-            socketPosts.getCategory({ uid: voterUid }, pid, (err, postCid) => {
-                assert.ifError(err);
-                assert.equal(cid, postCid);
-                done();
-            });
+        it('should get post category', async () => {
+            try {
+                await socketPosts.getCategory({ uid: voterUid }, pid, (err, postCid) => {
+                    assert.ifError(err);
+                    assert.equal(cid, postCid);
+                });
+            } catch (err) {
+                assert(false);
+            }
         });
 
-        it('should error with invalid data', (done) => {
-            socketPosts.getPidIndex({ uid: voterUid }, null, (err) => {
-                assert.equal(err.message, '[[error:invalid-data]]');
-                done();
-            });
+        it('should error with invalid data', async () => {
+            try {
+                await socketPosts.getPidIndex({ uid: voterUid }, null, (err) => {
+                    assert.equal(err.message, '[[error:invalid-data]]');
+                });
+            } catch (err) {
+                assert(false);
+            }
         });
 
         it('should get pid index', (done) => {
@@ -1098,7 +1116,7 @@ describe('Post\'s', () => {
             const oldValue = meta.config.groupsExemptFromPostQueue;
             meta.config.groupsExemptFromPostQueue = ['registered-users'];
             const uid = await user.create({ username: 'mergeexemptuser' });
-            const result = await apiTopics.create({ uid: uid, emit: () => {} }, { title: 'should not be queued', content: 'topic content', cid: cid });
+            const result = await apiTopics.create({ uid: uid, emit: () => { } }, { title: 'should not be queued', content: 'topic content', cid: cid });
             assert.strictEqual(result.title, 'should not be queued');
             meta.config.groupsExemptFromPostQueue = oldValue;
         });


### PR DESCRIPTION
Fixes #15 
created correct conversion of src/posts/data.js to data.ts
added more fields to the PostObject in src/types/posts.ts
changed 6 test functions that use async functions from data.js. These test functions use the done function but now use (async and await) with the try&catch ... this is because they test functions from data.js which have async and await inside them.