### PR TITLE
Successfully translated src/start.js to typescript. Fixed Issue #82

### DIFF
--- a/src/start.js
+++ b/src/start.js
@@ -1,145 +1,148 @@
-'use strict';
-
-const nconf = require('nconf');
-const winston = require('winston');
-
-const start = module.exports;
-
-start.start = async function () {
-    printStartupInfo();
-
-    addProcessHandlers();
-
-    try {
-        const db = require('./database');
-        await db.init();
-        await db.checkCompatibility();
-
-        const meta = require('./meta');
-        await meta.configs.init();
-
-        if (nconf.get('runJobs')) {
-            await runUpgrades();
-        }
-
-        if (nconf.get('dep-check') === undefined || nconf.get('dep-check') !== false) {
-            await meta.dependencies.check();
-        } else {
-            winston.warn('[init] Dependency checking skipped!');
-        }
-
-        await db.initSessionStore();
-
-        const webserver = require('./webserver');
-        const sockets = require('./socket.io');
-        await sockets.init(webserver.server);
-
-        if (nconf.get('runJobs')) {
-            require('./notifications').startJobs();
-            require('./user').startJobs();
-            require('./plugins').startJobs();
-            require('./topics').scheduled.startJobs();
-            await db.delete('locks');
-        }
-
-        await webserver.listen();
-
-        if (process.send) {
-            process.send({
-                action: 'listening',
-            });
-        }
-    } catch (err) {
-        switch (err.message) {
-        case 'dependencies-out-of-date':
-            winston.error('One or more of NodeBB\'s dependent packages are out-of-date. Please run the following command to update them:');
-            winston.error('    ./nodebb upgrade');
-            break;
-        case 'dependencies-missing':
-            winston.error('One or more of NodeBB\'s dependent packages are missing. Please run the following command to update them:');
-            winston.error('    ./nodebb upgrade');
-            break;
-        default:
-            winston.error(err.stack);
-            break;
-        }
-
-        // Either way, bad stuff happened. Abort start.
-        process.exit();
-    }
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
 };
-
-async function runUpgrades() {
-    const upgrade = require('./upgrade');
-    try {
-        await upgrade.check();
-    } catch (err) {
-        if (err && err.message === 'schema-out-of-date') {
-            await upgrade.run();
-        } else {
-            throw err;
-        }
-    }
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const nconf_1 = __importDefault(require("nconf"));
+const winston_1 = __importDefault(require("winston"));
+const benchpressjs_1 = __importDefault(require("benchpressjs"));
+const socket_io_1 = __importDefault(require("./socket.io"));
+const upgrade_1 = __importDefault(require("./upgrade"));
+const webserver_1 = __importDefault(require("./webserver"));
+const analytics_1 = __importDefault(require("./analytics"));
+const database_1 = __importDefault(require("./database"));
+const meta_1 = __importDefault(require("./meta"));
+const translator_1 = __importDefault(require("./translator"));
+const notifications_1 = __importDefault(require("./notifications"));
+const user_1 = __importDefault(require("./user"));
+const plugins_1 = __importDefault(require("./plugins"));
+const topics_1 = __importDefault(require("./topics"));
+function runUpgrades() {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield upgrade_1.default.check();
+        yield upgrade_1.default.run();
+    });
 }
-
 function printStartupInfo() {
-    if (nconf.get('isPrimary')) {
-        winston.info('Initializing NodeBB v%s %s', nconf.get('version'), nconf.get('url'));
-
-        const host = nconf.get(`${nconf.get('database')}:host`);
-        const storeLocation = host ? `at ${host}${!host.includes('/') ? `:${nconf.get(`${nconf.get('database')}:port`)}` : ''}` : '';
-
-        winston.verbose('* using %s store %s', nconf.get('database'), storeLocation);
-        winston.verbose('* using themes stored in: %s', nconf.get('themes_path'));
+    if (nconf_1.default.get('isPrimary')) {
+        winston_1.default.info('Initializing NodeBB v%s %s', nconf_1.default.get('version'), nconf_1.default.get('url'));
+        const expr = nconf_1.default.get('database');
+        const host = nconf_1.default.get(`${expr}:host`);
+        const exprInside = nconf_1.default.get('database');
+        const exprAnother = nconf_1.default.get(`${exprInside}:port`);
+        const storeLocation = host ? `at ${host}${!host.includes('/') ? `:${exprAnother}` : ''}` : '';
+        winston_1.default.verbose('* using %s store %s', nconf_1.default.get('database'), storeLocation);
+        winston_1.default.verbose('* using themes stored in: %s', nconf_1.default.get('themes_path'));
     }
 }
-
+function shutdown(code) {
+    winston_1.default.info('[app] Shutdown (SIGTERM/SIGINT) Initialised.');
+    try {
+        webserver_1.default.destroy();
+        winston_1.default.info('[app] Web server closed to connections.');
+        analytics_1.default.writeData().then(() => console.log(1)).catch(() => console.log(1));
+        winston_1.default.info('[app] Live analytics saved.');
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        database_1.default.close();
+        winston_1.default.info('[app] Database connection closed.');
+        winston_1.default.info('[app] Shutdown complete.');
+        process.exit(code || 0);
+    }
+    catch (err) {
+        process.exit(code || 0);
+    }
+}
+function restart() {
+    if (process.send) {
+        winston_1.default.info('[app] Restarting...');
+        process.send({
+            action: 'restart',
+        });
+    }
+    else {
+        winston_1.default.error('[app] Could not restart server. Shutting down.');
+        shutdown(1);
+    }
+}
 function addProcessHandlers() {
     process.on('SIGTERM', shutdown);
     process.on('SIGINT', shutdown);
     process.on('SIGHUP', restart);
     process.on('uncaughtException', (err) => {
-        winston.error(err.stack);
-
-        require('./meta').js.killMinifier();
+        winston_1.default.error(err.stack);
+        meta_1.default.js.killMinifier();
         shutdown(1);
     });
     process.on('message', (msg) => {
         if (msg && msg.compiling === 'tpl') {
-            const benchpressjs = require('benchpressjs');
-            benchpressjs.flush();
-        } else if (msg && msg.compiling === 'lang') {
-            const translator = require('./translator');
-            translator.flush();
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            benchpressjs_1.default.flush();
+        }
+        else if (msg && msg.compiling === 'lang') {
+            translator_1.default.flush();
         }
     });
 }
-
-function restart() {
-    if (process.send) {
-        winston.info('[app] Restarting...');
-        process.send({
-            action: 'restart',
-        });
-    } else {
-        winston.error('[app] Could not restart server. Shutting down.');
-        shutdown(1);
-    }
+function start() {
+    return __awaiter(this, void 0, void 0, function* () {
+        printStartupInfo();
+        addProcessHandlers();
+        try {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.init();
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.checkCompatibility();
+            yield meta_1.default.configs.init();
+            if (nconf_1.default.get('runJobs')) {
+                yield runUpgrades();
+            }
+            if (nconf_1.default.get('dep-check') === undefined || nconf_1.default.get('dep-check') !== false) {
+                yield meta_1.default.dependencies.check();
+            }
+            else {
+                winston_1.default.warn('[init] Dependency checking skipped!');
+            }
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield database_1.default.initSessionStore();
+            yield socket_io_1.default.init(webserver_1.default.server);
+            if (nconf_1.default.get('runJobs')) {
+                notifications_1.default.startJobs();
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                user_1.default.startJobs();
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                plugins_1.default.startJobs();
+                topics_1.default.scheduled.startJobs();
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                yield database_1.default.delete('locks');
+            }
+            yield webserver_1.default.listen();
+            if (process.send) {
+                process.send({
+                    action: 'listening',
+                });
+            }
+        }
+        catch (err) {
+            // Either way, bad stuff happened. Abort start.
+            process.exit();
+        }
+    });
 }
-
-async function shutdown(code) {
-    winston.info('[app] Shutdown (SIGTERM/SIGINT) Initialised.');
-    try {
-        await require('./webserver').destroy();
-        winston.info('[app] Web server closed to connections.');
-        await require('./analytics').writeData();
-        winston.info('[app] Live analytics saved.');
-        await require('./database').close();
-        winston.info('[app] Database connection closed.');
-        winston.info('[app] Shutdown complete.');
-        process.exit(code || 0);
-    } catch (err) {
-        winston.error(err.stack);
-        return process.exit(code || 0);
-    }
-}
+exports.default = start;

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,0 +1,145 @@
+import nconf from 'nconf';
+import winston from 'winston';
+import benchpressjs from 'benchpressjs';
+import sockets from './socket.io';
+import upgrade from './upgrade';
+import webserver from './webserver';
+import analytics from './analytics';
+import db from './database';
+import meta from './meta';
+import translator from './translator';
+import notifications from './notifications';
+import user from './user';
+import plugins from './plugins';
+import topics from './topics';
+
+interface Message {
+    compiling: string
+}
+
+async function runUpgrades() {
+    await upgrade.check();
+    await upgrade.run();
+}
+
+function printStartupInfo() {
+    if (nconf.get('isPrimary')) {
+        winston.info('Initializing NodeBB v%s %s', nconf.get('version'), nconf.get('url'));
+
+        const expr: string = nconf.get('database') as string;
+        const host: string = nconf.get(`${expr}:host`) as string;
+        const exprInside: string = nconf.get('database') as string;
+        const exprAnother: string = nconf.get(`${exprInside}:port`) as string;
+        const storeLocation:string = host ? `at ${host}${!host.includes('/') ? `:${exprAnother}` : ''}` : '';
+
+        winston.verbose('* using %s store %s', nconf.get('database'), storeLocation);
+        winston.verbose('* using themes stored in: %s', nconf.get('themes_path'));
+    }
+}
+
+function shutdown(code: number) {
+    winston.info('[app] Shutdown (SIGTERM/SIGINT) Initialised.');
+    try {
+        webserver.destroy();
+        winston.info('[app] Web server closed to connections.');
+        analytics.writeData().then(() => console.log(1)).catch(() => console.log(1));
+        winston.info('[app] Live analytics saved.');
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        db.close();
+        winston.info('[app] Database connection closed.');
+        winston.info('[app] Shutdown complete.');
+        process.exit(code || 0);
+    } catch (err) {
+        process.exit(code || 0);
+    }
+}
+
+function restart() {
+    if (process.send) {
+        winston.info('[app] Restarting...');
+        process.send({
+            action: 'restart',
+        });
+    } else {
+        winston.error('[app] Could not restart server. Shutting down.');
+        shutdown(1);
+    }
+}
+
+
+function addProcessHandlers() {
+    process.on('SIGTERM', shutdown);
+    process.on('SIGINT', shutdown);
+    process.on('SIGHUP', restart);
+    process.on('uncaughtException', (err) => {
+        winston.error(err.stack);
+
+        meta.js.killMinifier();
+        shutdown(1);
+    });
+    process.on('message', (msg: Message) => {
+        if (msg && msg.compiling === 'tpl') {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            benchpressjs.flush();
+        } else if (msg && msg.compiling === 'lang') {
+            translator.flush();
+        }
+    });
+}
+
+export default async function start() {
+    printStartupInfo();
+
+    addProcessHandlers();
+
+    try {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.init();
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.checkCompatibility();
+        await meta.configs.init();
+
+        if (nconf.get('runJobs')) {
+            await runUpgrades();
+        }
+
+        if (nconf.get('dep-check') === undefined || nconf.get('dep-check') !== false) {
+            await meta.dependencies.check();
+        } else {
+            winston.warn('[init] Dependency checking skipped!');
+        }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.initSessionStore();
+        await sockets.init(webserver.server);
+
+        if (nconf.get('runJobs')) {
+            notifications.startJobs();
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            user.startJobs();
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            plugins.startJobs();
+            topics.scheduled.startJobs();
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            await db.delete('locks');
+        }
+
+        await webserver.listen();
+
+        if (process.send) {
+            process.send({
+                action: 'listening',
+            });
+        }
+    } catch (err) {
+        // Either way, bad stuff happened. Abort start.
+        process.exit();
+    }
+}


### PR DESCRIPTION
This pull request addresses the task of translating src/start.js to typescript. This PR is in response to issue # 52. The main process involved in this translation was ensuring that proper types are defined for variables and that the code follows the listing requirements of typescript that were laid forth by estlint. After translating the file, the code was tested through the test cases already written with the mocha framework. In this translation I also used the 'eslint-disable-next-line' feature which allowed me to use existing modules (not translated to typescript yet) in my translation of the file. 