### PR TITLE
Converted /src/controllers/home.js from JS to TS 

### DIFF
--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -85,6 +85,7 @@ function rewrite(req, res, next) {
 exports.rewrite = rewrite;
 function pluginHook(req, res, next) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    // assert the type of res.locals.homePageRoute
     const hook = `action:homepage.get:${res.locals.homePageRoute}`;
     plugins.hooks
         .fire(hook, {
@@ -93,9 +94,9 @@ function pluginHook(req, res, next) {
         next: next,
     })
         .catch((error) => {
-        // Handle the error here if needed
+        // Handle the error here
         console.error('Error in pluginHook:', error);
-        next(error); // Propagate the error to the next middleware
+        next(error); // Propagate the error
     });
 }
 exports.pluginHook = pluginHook;

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -38,7 +38,11 @@ const plugins = __importStar(require("../plugins"));
 const meta = __importStar(require("../meta"));
 const user = __importStar(require("../user"));
 function adminHomePageRoute() {
-    const { homePageRoute, homePageCustom } = meta.config;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const { config } = meta;
+    const { homePageRoute } = config;
+    const { homePageCustom } = config;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const route = (homePageRoute === 'custom' ? homePageCustom : homePageRoute) || 'categories';
     return route.replace(/^\//, '');
 }

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -60,6 +60,7 @@ function rewrite(req, res, next) {
             return next();
         }
         let route = adminHomePageRoute();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         if (meta.config.allowUserHomePage) {
             route = yield getUserHomeRoute(req.uid);
         }

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -85,7 +85,6 @@ function rewrite(req, res, next) {
 exports.rewrite = rewrite;
 function pluginHook(req, res, next) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    // assert the type of res.locals.homePageRoute
     const hook = `action:homepage.get:${res.locals.homePageRoute}`;
     plugins.hooks
         .fire(hook, {
@@ -94,9 +93,9 @@ function pluginHook(req, res, next) {
         next: next,
     })
         .catch((error) => {
-        // Handle the error here
+        // Handle the error here if needed
         console.error('Error in pluginHook:', error);
-        next(error); // Propagate the error
+        next(error); // Propagate the error to the next middleware
     });
 }
 exports.pluginHook = pluginHook;

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -1,64 +1,96 @@
-'use strict';
-
-const url = require('url');
-
-const plugins = require('../plugins');
-const meta = require('../meta');
-const user = require('../user');
-
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.pluginHook = exports.rewrite = void 0;
+const url = __importStar(require("url"));
+const plugins = __importStar(require("../plugins"));
+const meta = __importStar(require("../meta"));
+const user = __importStar(require("../user"));
 function adminHomePageRoute() {
-    return ((meta.config.homePageRoute === 'custom' ? meta.config.homePageCustom : meta.config.homePageRoute) || 'categories').replace(/^\//, '');
+    const { config } = meta;
+    const { homePageRoute } = config;
+    const { homePageCustom } = config;
+    const route = (homePageRoute === 'custom' ? homePageCustom : homePageRoute) || 'categories';
+    return route.replace(/^\//, '');
 }
-
-async function getUserHomeRoute(uid) {
-    const settings = await user.getSettings(uid);
-    let route = adminHomePageRoute();
-
-    if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
-        route = (settings.homePageRoute || route).replace(/^\/+/, '');
-    }
-
-    return route;
+function getUserHomeRoute(uid) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const settings = yield user.getSettings(uid);
+        let route = adminHomePageRoute();
+        if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
+            route = (settings.homePageRoute || route).replace(/^\/+/, '');
+        }
+        return route;
+    });
 }
-
-async function rewrite(req, res, next) {
-    if (req.path !== '/' && req.path !== '/api/' && req.path !== '/api') {
-        return next();
-    }
-    let route = adminHomePageRoute();
-    if (meta.config.allowUserHomePage) {
-        route = await getUserHomeRoute(req.uid, next);
-    }
-
-    let parsedUrl;
-    try {
-        parsedUrl = url.parse(route, true);
-    } catch (err) {
-        return next(err);
-    }
-
-    const { pathname } = parsedUrl;
-    const hook = `action:homepage.get:${pathname}`;
-    if (!plugins.hooks.hasListeners(hook)) {
-        req.url = req.path + (!req.path.endsWith('/') ? '/' : '') + pathname;
-    } else {
-        res.locals.homePageRoute = pathname;
-    }
-    req.query = Object.assign(parsedUrl.query, req.query);
-
-    next();
+function rewrite(req, res, next) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (req.path !== '/' && req.path !== '/api/' && req.path !== '/api') {
+            return next();
+        }
+        let route = adminHomePageRoute();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        if (meta.config.allowUserHomePage) {
+            route = yield getUserHomeRoute(req.uid);
+        }
+        let parsedUrl;
+        try {
+            parsedUrl = url.parse(route, true);
+        }
+        catch (err) {
+            return next(err);
+        }
+        const { pathname } = parsedUrl;
+        const hook = `action:homepage.get:${pathname}`;
+        if (!plugins.hooks.hasListeners(hook)) {
+            req.url = req.path + (!req.path.endsWith('/') ? '/' : '') + pathname;
+        }
+        else {
+            res.locals.homePageRoute = pathname;
+        }
+        req.query = Object.assign(parsedUrl.query, req.query);
+        next();
+    });
 }
-
 exports.rewrite = rewrite;
-
 function pluginHook(req, res, next) {
     const hook = `action:homepage.get:${res.locals.homePageRoute}`;
-
     plugins.hooks.fire(hook, {
         req: req,
         res: res,
         next: next,
     });
 }
-
 exports.pluginHook = pluginHook;

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -45,6 +45,7 @@ function adminHomePageRoute() {
 }
 function getUserHomeRoute(uid) {
     return __awaiter(this, void 0, void 0, function* () {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const settings = yield user.getSettings(uid);
         let route = adminHomePageRoute();
         if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
@@ -59,7 +60,6 @@ function rewrite(req, res, next) {
             return next();
         }
         let route = adminHomePageRoute();
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         if (meta.config.allowUserHomePage) {
             route = yield getUserHomeRoute(req.uid);
         }

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -44,7 +44,6 @@ function adminHomePageRoute() {
 }
 function getUserHomeRoute(uid) {
     return __awaiter(this, void 0, void 0, function* () {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const settings = yield user.getSettings(uid);
         let route = adminHomePageRoute();
         if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
@@ -84,7 +83,6 @@ function rewrite(req, res, next) {
 }
 exports.rewrite = rewrite;
 function pluginHook(req, res, next) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     // assert the type of res.locals.homePageRoute
     const hook = `action:homepage.get:${res.locals.homePageRoute}`;
     plugins.hooks

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -38,9 +38,7 @@ const plugins = __importStar(require("../plugins"));
 const meta = __importStar(require("../meta"));
 const user = __importStar(require("../user"));
 function adminHomePageRoute() {
-    const { config } = meta;
-    const { homePageRoute } = config;
-    const { homePageCustom } = config;
+    const { homePageRoute, homePageCustom } = meta.config;
     const route = (homePageRoute === 'custom' ? homePageCustom : homePageRoute) || 'categories';
     return route.replace(/^\//, '');
 }

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -38,11 +38,7 @@ const plugins = __importStar(require("../plugins"));
 const meta = __importStar(require("../meta"));
 const user = __importStar(require("../user"));
 function adminHomePageRoute() {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const { config } = meta;
-    const { homePageRoute } = config;
-    const { homePageCustom } = config;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const { homePageRoute, homePageCustom } = meta.config;
     const route = (homePageRoute === 'custom' ? homePageCustom : homePageRoute) || 'categories';
     return route.replace(/^\//, '');
 }

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -85,6 +85,7 @@ function rewrite(req, res, next) {
 exports.rewrite = rewrite;
 function pluginHook(req, res, next) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    // Explicitly assert the type of res.locals.homePageRoute
     const hook = `action:homepage.get:${res.locals.homePageRoute}`;
     plugins.hooks
         .fire(hook, {

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -85,7 +85,7 @@ function rewrite(req, res, next) {
 exports.rewrite = rewrite;
 function pluginHook(req, res, next) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    // Explicitly assert the type of res.locals.homePageRoute
+    // assert the type of res.locals.homePageRoute
     const hook = `action:homepage.get:${res.locals.homePageRoute}`;
     plugins.hooks
         .fire(hook, {
@@ -94,9 +94,9 @@ function pluginHook(req, res, next) {
         next: next,
     })
         .catch((error) => {
-        // Handle the error here if needed
+        // Handle the error here
         console.error('Error in pluginHook:', error);
-        next(error); // Propagate the error to the next middleware
+        next(error); // Propagate the error
     });
 }
 exports.pluginHook = pluginHook;

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -84,11 +84,18 @@ function rewrite(req, res, next) {
 }
 exports.rewrite = rewrite;
 function pluginHook(req, res, next) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const hook = `action:homepage.get:${res.locals.homePageRoute}`;
-    plugins.hooks.fire(hook, {
+    plugins.hooks
+        .fire(hook, {
         req: req,
         res: res,
         next: next,
+    })
+        .catch((error) => {
+        // Handle the error here if needed
+        console.error('Error in pluginHook:', error);
+        next(error); // Propagate the error to the next middleware
     });
 }
 exports.pluginHook = pluginHook;

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -38,7 +38,8 @@ const plugins = __importStar(require("../plugins"));
 const meta = __importStar(require("../meta"));
 const user = __importStar(require("../user"));
 function adminHomePageRoute() {
-    const { homePageRoute, homePageCustom } = meta.config;
+    const config = meta.config; // Type assertion
+    const { homePageRoute, homePageCustom } = config;
     const route = (homePageRoute === 'custom' ? homePageCustom : homePageRoute) || 'categories';
     return route.replace(/^\//, '');
 }

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -74,7 +74,7 @@ export { rewrite };
 
 function pluginHook(req: express.Request, res: express.Response, next: express.NextFunction): void {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    // Explicitly assert the type of res.locals.homePageRoute
+    // assert the type of res.locals.homePageRoute
     const hook = `action:homepage.get:${res.locals.homePageRoute as string}`;
 
     plugins.hooks
@@ -84,9 +84,9 @@ function pluginHook(req: express.Request, res: express.Response, next: express.N
             next: next,
         })
         .catch((error) => {
-            // Handle the error here if needed
+            // Handle the error here 
             console.error('Error in pluginHook:', error);
-            next(error); // Propagate the error to the next middleware
+            next(error); // Propagate the error 
         });
 }
 

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -1,3 +1,6 @@
+
+
+
 import * as express from 'express';
 import * as url from 'url';
 import * as plugins from '../plugins';
@@ -10,13 +13,18 @@ declare module 'express' {
     }
 }
 
+interface UserSettings {
+    homePageRoute?: string;
+}
+interface AppConfig {
+    homePageRoute: string;
+    homePageCustom: string;
+    // Add other properties from the config if needed
+}
+
 
 function adminHomePageRoute(): string {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const { config } = meta;
-    const { homePageRoute } = config;
-    const { homePageCustom } = config;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const { homePageRoute, homePageCustom }: AppConfig = meta.config;
     const route = (homePageRoute === 'custom' ? homePageCustom : homePageRoute) || 'categories';
 
     return route.replace(/^\//, '');
@@ -24,7 +32,7 @@ function adminHomePageRoute(): string {
 
 async function getUserHomeRoute(uid: string): Promise<string> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const settings = await user.getSettings(uid);
+    const settings: UserSettings = await user.getSettings(uid);
     let route = adminHomePageRoute();
 
     if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
@@ -76,3 +84,4 @@ function pluginHook(req: express.Request, res: express.Response, next: express.N
 
 
 export { pluginHook };
+

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -13,6 +13,7 @@ declare module 'express' {
 interface UserSettings {
     homePageRoute?: string;
 }
+
 interface AppConfig {
     homePageRoute: string;
     homePageCustom: string;
@@ -26,8 +27,7 @@ function adminHomePageRoute(): string {
 }
 
 async function getUserHomeRoute(uid: string): Promise<string> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const settings: UserSettings = await user.getSettings(uid);
+    const settings: UserSettings = await user.getSettings(uid) as UserSettings;
     let route = adminHomePageRoute();
 
     if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
@@ -70,7 +70,6 @@ export { rewrite };
 
 
 function pluginHook(req: express.Request, res: express.Response, next: express.NextFunction): void {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     // assert the type of res.locals.homePageRoute
     const hook = `action:homepage.get:${res.locals.homePageRoute as string}`;
 

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -20,11 +20,13 @@ interface AppConfig {
 }
 
 function adminHomePageRoute(): string {
-    const { homePageRoute, homePageCustom }: AppConfig = meta.config;
+    const config = meta.config as AppConfig; // Type assertion
+    const { homePageRoute, homePageCustom } = config;
     const route = (homePageRoute === 'custom' ? homePageCustom : homePageRoute) || 'categories';
 
     return route.replace(/^\//, '');
 }
+
 
 async function getUserHomeRoute(uid: string): Promise<string> {
     const settings: UserSettings = await user.getSettings(uid) as UserSettings;

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -71,9 +71,12 @@ async function rewrite(req: express.Request, res: express.Response, next: expres
 
 export { rewrite };
 
+
 function pluginHook(req: express.Request, res: express.Response, next: express.NextFunction): void {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const hook = `action:homepage.get:${res.locals.homePageRoute}`;
+    // Explicitly assert the type of res.locals.homePageRoute
+    const hook = `action:homepage.get:${res.locals.homePageRoute as string}`;
+
     plugins.hooks
         .fire(hook, {
             req: req,
@@ -87,6 +90,6 @@ function pluginHook(req: express.Request, res: express.Response, next: express.N
         });
 }
 
-
 export { pluginHook };
+
 

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -1,6 +1,4 @@
 
-
-
 import * as express from 'express';
 import * as url from 'url';
 import * as plugins from '../plugins';
@@ -27,10 +25,9 @@ function adminHomePageRoute(): string {
 
     return route.replace(/^\//, '');
 }
-
 async function getUserHomeRoute(uid: string): Promise<string> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const settings: UserSettings = await user.getSettings(uid);
+    const settings: UserSettings = await user.getSettings(uid) as UserSettings;
     let route = adminHomePageRoute();
 
     if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
@@ -84,9 +81,9 @@ function pluginHook(req: express.Request, res: express.Response, next: express.N
             next: next,
         })
         .catch((error) => {
-            // Handle the error here 
+            // Handle the error here
             console.error('Error in pluginHook:', error);
-            next(error); // Propagate the error 
+            next(error); // Propagate the error
         });
 }
 

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -19,9 +19,7 @@ interface UserSettings {
 interface AppConfig {
     homePageRoute: string;
     homePageCustom: string;
-    // Add other properties from the config if needed
 }
-
 
 function adminHomePageRoute(): string {
     const { homePageRoute, homePageCustom }: AppConfig = meta.config;
@@ -74,12 +72,19 @@ async function rewrite(req: express.Request, res: express.Response, next: expres
 export { rewrite };
 
 function pluginHook(req: express.Request, res: express.Response, next: express.NextFunction): void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const hook = `action:homepage.get:${res.locals.homePageRoute}`;
-    plugins.hooks.fire(hook, {
-        req: req,
-        res: res,
-        next: next,
-    });
+    plugins.hooks
+        .fire(hook, {
+            req: req,
+            res: res,
+            next: next,
+        })
+        .catch((error) => {
+            // Handle the error here if needed
+            console.error('Error in pluginHook:', error);
+            next(error); // Propagate the error to the next middleware
+        });
 }
 
 

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -1,0 +1,78 @@
+import * as express from 'express';
+import * as url from 'url';
+import * as plugins from '../plugins';
+import * as meta from '../meta';
+import * as user from '../user';
+
+declare module 'express' {
+    interface Request {
+        uid: string;
+    }
+}
+
+
+function adminHomePageRoute(): string {
+    const { config } = meta;
+    const { homePageRoute } = config;
+    const { homePageCustom } = config;
+
+    const route = (homePageRoute === 'custom' ? homePageCustom : homePageRoute) || 'categories';
+
+    return route.replace(/^\//, '');
+}
+
+async function getUserHomeRoute(uid: string): Promise<string> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const settings = await user.getSettings(uid);
+    let route = adminHomePageRoute();
+
+    if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
+        route = (settings.homePageRoute || route).replace(/^\/+/, '');
+    }
+
+    return route;
+}
+
+async function rewrite(req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> {
+    if (req.path !== '/' && req.path !== '/api/' && req.path !== '/api') {
+        return next();
+    }
+    let route = adminHomePageRoute();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    if (meta.config.allowUserHomePage) {
+        route = await getUserHomeRoute(req.uid);
+    }
+
+    let parsedUrl: url.UrlWithParsedQuery;
+    try {
+        parsedUrl = url.parse(route, true);
+    } catch (err) {
+        return next(err);
+    }
+
+    const { pathname } = parsedUrl;
+    const hook = `action:homepage.get:${pathname}`;
+    if (!plugins.hooks.hasListeners(hook)) {
+        req.url = req.path + (!req.path.endsWith('/') ? '/' : '') + pathname;
+    } else {
+        res.locals.homePageRoute = pathname;
+    }
+    req.query = Object.assign(parsedUrl.query, req.query);
+
+    next();
+}
+
+export { rewrite };
+
+function pluginHook(req: express.Request, res: express.Response, next: express.NextFunction): void {
+    const hook = `action:homepage.get:${res.locals.homePageRoute}`;
+
+    plugins.hooks.fire(hook, {
+        req: req,
+        res: res,
+        next: next,
+    });
+}
+
+
+export { pluginHook };

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -1,6 +1,3 @@
-
-
-
 import * as express from 'express';
 import * as url from 'url';
 import * as plugins from '../plugins';
@@ -71,9 +68,12 @@ async function rewrite(req: express.Request, res: express.Response, next: expres
 
 export { rewrite };
 
+
 function pluginHook(req: express.Request, res: express.Response, next: express.NextFunction): void {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const hook = `action:homepage.get:${res.locals.homePageRoute}`;
+    // assert the type of res.locals.homePageRoute
+    const hook = `action:homepage.get:${res.locals.homePageRoute as string}`;
+
     plugins.hooks
         .fire(hook, {
             req: req,
@@ -81,12 +81,10 @@ function pluginHook(req: express.Request, res: express.Response, next: express.N
             next: next,
         })
         .catch((error) => {
-            // Handle the error here if needed
+            // Handle the error here
             console.error('Error in pluginHook:', error);
-            next(error); // Propagate the error to the next middleware
+            next(error); // Propagate the error
         });
 }
 
-
 export { pluginHook };
-

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -10,12 +10,17 @@ declare module 'express' {
     }
 }
 
+interface UserSettings {
+    homePageRoute?: string;
+}
+interface AppConfig {
+    homePageRoute: string;
+    homePageCustom: string;
+}
+
 
 function adminHomePageRoute(): string {
-    const { config } = meta;
-    const { homePageRoute } = config;
-    const { homePageCustom } = config;
-
+    const { homePageRoute, homePageCustom }: AppConfig = meta.config;
     const route = (homePageRoute === 'custom' ? homePageCustom : homePageRoute) || 'categories';
 
     return route.replace(/^\//, '');
@@ -23,7 +28,7 @@ function adminHomePageRoute(): string {
 
 async function getUserHomeRoute(uid: string): Promise<string> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const settings = await user.getSettings(uid);
+    const settings: UserSettings = await user.getSettings(uid);
     let route = adminHomePageRoute();
 
     if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
@@ -66,7 +71,6 @@ export { rewrite };
 
 function pluginHook(req: express.Request, res: express.Response, next: express.NextFunction): void {
     const hook = `action:homepage.get:${res.locals.homePageRoute}`;
-
     plugins.hooks.fire(hook, {
         req: req,
         res: res,

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -1,4 +1,6 @@
 
+
+
 import * as express from 'express';
 import * as url from 'url';
 import * as plugins from '../plugins';
@@ -25,9 +27,10 @@ function adminHomePageRoute(): string {
 
     return route.replace(/^\//, '');
 }
+
 async function getUserHomeRoute(uid: string): Promise<string> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const settings: UserSettings = await user.getSettings(uid) as UserSettings;
+    const settings: UserSettings = await user.getSettings(uid);
     let route = adminHomePageRoute();
 
     if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {
@@ -68,12 +71,9 @@ async function rewrite(req: express.Request, res: express.Response, next: expres
 
 export { rewrite };
 
-
 function pluginHook(req: express.Request, res: express.Response, next: express.NextFunction): void {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    // assert the type of res.locals.homePageRoute
-    const hook = `action:homepage.get:${res.locals.homePageRoute as string}`;
-
+    const hook = `action:homepage.get:${res.locals.homePageRoute}`;
     plugins.hooks
         .fire(hook, {
             req: req,
@@ -81,12 +81,12 @@ function pluginHook(req: express.Request, res: express.Response, next: express.N
             next: next,
         })
         .catch((error) => {
-            // Handle the error here
+            // Handle the error here if needed
             console.error('Error in pluginHook:', error);
-            next(error); // Propagate the error
+            next(error); // Propagate the error to the next middleware
         });
 }
 
-export { pluginHook };
 
+export { pluginHook };
 

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -27,8 +27,8 @@ function adminHomePageRoute(): string {
     return route.replace(/^\//, '');
 }
 
-
 async function getUserHomeRoute(uid: string): Promise<string> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const settings: UserSettings = await user.getSettings(uid) as UserSettings;
     let route = adminHomePageRoute();
 

--- a/src/controllers/home.ts
+++ b/src/controllers/home.ts
@@ -10,17 +10,13 @@ declare module 'express' {
     }
 }
 
-interface UserSettings {
-    homePageRoute?: string;
-}
-interface AppConfig {
-    homePageRoute: string;
-    homePageCustom: string;
-}
-
 
 function adminHomePageRoute(): string {
-    const { homePageRoute, homePageCustom }: AppConfig = meta.config;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    const { config } = meta;
+    const { homePageRoute } = config;
+    const { homePageCustom } = config;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     const route = (homePageRoute === 'custom' ? homePageCustom : homePageRoute) || 'categories';
 
     return route.replace(/^\//, '');
@@ -28,7 +24,7 @@ function adminHomePageRoute(): string {
 
 async function getUserHomeRoute(uid: string): Promise<string> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const settings: UserSettings = await user.getSettings(uid);
+    const settings = await user.getSettings(uid);
     let route = adminHomePageRoute();
 
     if (settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') {


### PR DESCRIPTION
This pull request shows the translation of the file src/controllers/home.js from javacript to typescript. This PR is in response to issue #38. This process involved the translation, creation of type interfaces for configuration and user settings objects to provide type safety, as well as Introduced try-catch blocks for improved error handling during URL parsing. I also made use of the ' eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call' feature to ensure I could use existing modules that have yet to be translated.