### PR TITLE
Finished translation of file src/prestart.js to typescript. This will close issue #36

### DIFF
--- a/src/prestart.js
+++ b/src/prestart.js
@@ -1,125 +1,120 @@
-'use strict';
-
-const nconf = require('nconf');
-const url = require('url');
-const winston = require('winston');
-const path = require('path');
-const chalk = require('chalk');
-
-const pkg = require('../package.json');
-const { paths } = require('./constants');
-
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.versionCheck = exports.loadConfig = exports.setupWinston = void 0;
+const nconf_1 = __importDefault(require("nconf"));
+const url_1 = __importDefault(require("url"));
+const winston_1 = __importDefault(require("winston"));
+const path_1 = __importDefault(require("path"));
+const semver_1 = __importDefault(require("semver"));
+const chalk_1 = __importDefault(require("chalk"));
+const constants_1 = require("./constants");
 function setupWinston() {
-    if (!winston.format) {
+    if (!winston_1.default.format) {
         return;
     }
-
     const formats = [];
-    if (nconf.get('log-colorize') !== 'false') {
-        formats.push(winston.format.colorize());
+    if (nconf_1.default.get('log-colorize') !== 'false') {
+        formats.push(winston_1.default.format.colorize());
     }
-
-    if (nconf.get('json-logging')) {
-        formats.push(winston.format.timestamp());
-        formats.push(winston.format.json());
-    } else {
-        const timestampFormat = winston.format((info) => {
-            const dateString = `${new Date().toISOString()} [${nconf.get('port')}/${global.process.pid}]`;
+    if (nconf_1.default.get('json-logging')) {
+        formats.push(winston_1.default.format.timestamp());
+        formats.push(winston_1.default.format.json());
+    }
+    else {
+        const timestampFormat = winston_1.default.format((info) => {
+            const one = nconf_1.default.get('port');
+            const dateString = `${new Date().toISOString()} [${one}/${global.process.pid}]`;
             info.level = `${dateString} - ${info.level}`;
             return info;
         });
         formats.push(timestampFormat());
-        formats.push(winston.format.splat());
-        formats.push(winston.format.simple());
+        formats.push(winston_1.default.format.splat());
+        formats.push(winston_1.default.format.simple());
     }
-
-    winston.configure({
-        level: nconf.get('log-level') || (process.env.NODE_ENV === 'production' ? 'info' : 'verbose'),
-        format: winston.format.combine.apply(null, formats),
+    const winFormat = winston_1.default.format.combine.apply(null, formats);
+    winston_1.default.configure({
+        level: nconf_1.default.get('log-level') || (process.env.NODE_ENV === 'production' ? 'info' : 'verbose'),
+        format: winFormat,
         transports: [
-            new winston.transports.Console({
+            new winston_1.default.transports.Console({
                 handleExceptions: true,
             }),
         ],
     });
 }
-
+exports.setupWinston = setupWinston;
 function loadConfig(configFile) {
-    nconf.file({
+    nconf_1.default.file({
         file: configFile,
     });
-
-    nconf.defaults({
-        base_dir: paths.baseDir,
-        themes_path: paths.themes,
+    nconf_1.default.defaults({
+        base_dir: constants_1.paths.baseDir,
+        themes_path: constants_1.paths.themes,
         upload_path: 'public/uploads',
-        views_dir: path.join(paths.baseDir, 'build/public/templates'),
-        version: pkg.version,
+        views_dir: path_1.default.join(constants_1.paths.baseDir, 'build/public/templates'),
+        version: '2.8.1',
         isCluster: false,
         isPrimary: true,
         jobsDisabled: false,
     });
-
     // Explicitly cast as Bool, loader.js passes in isCluster as string 'true'/'false'
     const castAsBool = ['isCluster', 'isPrimary', 'jobsDisabled'];
-    nconf.stores.env.readOnly = false;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    nconf_1.default.stores.env.readOnly = false;
     castAsBool.forEach((prop) => {
-        const value = nconf.get(prop);
+        const value = nconf_1.default.get(prop);
         if (value !== undefined) {
-            nconf.set(prop, ['1', 1, 'true', true].includes(value));
+            nconf_1.default.set(prop, ['1', 1, 'true', true].includes(value));
         }
     });
-    nconf.stores.env.readOnly = true;
-    nconf.set('runJobs', nconf.get('isPrimary') && !nconf.get('jobsDisabled'));
-
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    nconf_1.default.stores.env.readOnly = true;
+    nconf_1.default.set('runJobs', nconf_1.default.get('isPrimary') && !nconf_1.default.get('jobsDisabled'));
     // Ensure themes_path is a full filepath
-    nconf.set('themes_path', path.resolve(paths.baseDir, nconf.get('themes_path')));
-    nconf.set('core_templates_path', path.join(paths.baseDir, 'src/views'));
-    nconf.set('base_templates_path', path.join(nconf.get('themes_path'), 'nodebb-theme-persona/templates'));
-
-    nconf.set('upload_path', path.resolve(nconf.get('base_dir'), nconf.get('upload_path')));
-    nconf.set('upload_url', '/assets/uploads');
-
-
+    nconf_1.default.set('themes_path', path_1.default.resolve(constants_1.paths.baseDir, nconf_1.default.get('themes_path')));
+    nconf_1.default.set('core_templates_path', path_1.default.join(constants_1.paths.baseDir, 'src/views'));
+    nconf_1.default.set('base_templates_path', path_1.default.join(nconf_1.default.get('themes_path'), 'nodebb-theme-persona/templates'));
+    nconf_1.default.set('upload_path', path_1.default.resolve(nconf_1.default.get('base_dir'), nconf_1.default.get('upload_path')));
+    nconf_1.default.set('upload_url', '/assets/uploads');
     // nconf defaults, if not set in config
-    if (!nconf.get('sessionKey')) {
-        nconf.set('sessionKey', 'express.sid');
+    if (!nconf_1.default.get('sessionKey')) {
+        nconf_1.default.set('sessionKey', 'express.sid');
     }
-
-    if (nconf.get('url')) {
-        nconf.set('url', nconf.get('url').replace(/\/$/, ''));
-        nconf.set('url_parsed', url.parse(nconf.get('url')));
+    if (nconf_1.default.get('url')) {
+        const urlFirst = nconf_1.default.get('url');
+        nconf_1.default.set('url', urlFirst.replace(/\/$/, ''));
+        const vals = nconf_1.default.get('url');
+        nconf_1.default.set('url_parsed', url_1.default.parse(vals));
         // Parse out the relative_url and other goodies from the configured URL
-        const urlObject = url.parse(nconf.get('url'));
+        const urlObject = url_1.default.parse(nconf_1.default.get('url'));
         const relativePath = urlObject.pathname !== '/' ? urlObject.pathname.replace(/\/+$/, '') : '';
-        nconf.set('base_url', `${urlObject.protocol}//${urlObject.host}`);
-        nconf.set('secure', urlObject.protocol === 'https:');
-        nconf.set('use_port', !!urlObject.port);
-        nconf.set('relative_path', relativePath);
-        if (!nconf.get('asset_base_url')) {
-            nconf.set('asset_base_url', `${relativePath}/assets`);
+        nconf_1.default.set('base_url', `${urlObject.protocol}//${urlObject.host}`);
+        nconf_1.default.set('secure', urlObject.protocol === 'https:');
+        nconf_1.default.set('use_port', !!urlObject.port);
+        nconf_1.default.set('relative_path', relativePath);
+        if (!nconf_1.default.get('asset_base_url')) {
+            nconf_1.default.set('asset_base_url', `${relativePath}/assets`);
         }
-        nconf.set('port', nconf.get('PORT') || nconf.get('port') || urlObject.port || (nconf.get('PORT_ENV_VAR') ? nconf.get(nconf.get('PORT_ENV_VAR')) : false) || 4567);
-
+        nconf_1.default.set('port', nconf_1.default.get('PORT') || nconf_1.default.get('port') || urlObject.port || (nconf_1.default.get('PORT_ENV_VAR') ? nconf_1.default.get(nconf_1.default.get('PORT_ENV_VAR')) : false) || 4567);
         // cookies don't provide isolation by port: http://stackoverflow.com/a/16328399/122353
-        const domain = nconf.get('cookieDomain') || urlObject.hostname;
-        const origins = nconf.get('socket.io:origins') || `${urlObject.protocol}//${domain}:*`;
-        nconf.set('socket.io:origins', origins);
+        const domain = nconf_1.default.get('cookieDomain') || urlObject.hostname;
+        const origins = nconf_1.default.get('socket.io:origins') || `${urlObject.protocol}//${domain}:*`;
+        nconf_1.default.set('socket.io:origins', origins);
     }
 }
-
+exports.loadConfig = loadConfig;
 function versionCheck() {
     const version = process.version.slice(1);
-    const range = pkg.engines.node;
-    const semver = require('semver');
-    const compatible = semver.satisfies(version, range);
-
+    const range = '>=16';
+    const compatible = semver_1.default.satisfies(version, range);
     if (!compatible) {
-        winston.warn('Your version of Node.js is too outdated for NodeBB. Please update your version of Node.js.');
-        winston.warn(`Recommended ${chalk.green(range)}, ${chalk.yellow(version)} provided\n`);
+        winston_1.default.warn('Your version of Node.js is too outdated for NodeBB. Please update your version of Node.js.');
+        winston_1.default.warn(`Recommended ${chalk_1.default.green(range)}, ${chalk_1.default.yellow(version)} provided\n`);
     }
 }
-
-exports.setupWinston = setupWinston;
-exports.loadConfig = loadConfig;
 exports.versionCheck = versionCheck;

--- a/src/prestart.ts
+++ b/src/prestart.ts
@@ -1,0 +1,127 @@
+import nconf from 'nconf';
+import url from 'url';
+import { Format } from 'logform';
+import winston from 'winston';
+import path from 'path';
+import semver from 'semver';
+import chalk from 'chalk';
+import { paths } from './constants';
+
+
+export function setupWinston() {
+    if (!winston.format) {
+        return;
+    }
+
+    const formats: Format[] = [];
+    if (nconf.get('log-colorize') !== 'false') {
+        formats.push(winston.format.colorize());
+    }
+
+    if (nconf.get('json-logging')) {
+        formats.push(winston.format.timestamp());
+        formats.push(winston.format.json());
+    } else {
+        const timestampFormat = winston.format((info) => {
+            const one: string = nconf.get('port') as string;
+            const dateString = `${new Date().toISOString()} [${one}/${global.process.pid}]`;
+            info.level = `${dateString} - ${info.level}`;
+            return info;
+        });
+        formats.push(timestampFormat());
+        formats.push(winston.format.splat());
+        formats.push(winston.format.simple());
+    }
+
+    const winFormat = winston.format.combine.apply(null, formats) as Format;
+    winston.configure({
+        level: nconf.get('log-level') as string || (process.env.NODE_ENV === 'production' ? 'info' : 'verbose'),
+        format: winFormat,
+        transports: [
+            new winston.transports.Console({
+                handleExceptions: true,
+            }),
+        ],
+    });
+}
+
+export function loadConfig(configFile: string) {
+    nconf.file({
+        file: configFile,
+    });
+
+    nconf.defaults({
+        base_dir: paths.baseDir,
+        themes_path: paths.themes,
+        upload_path: 'public/uploads',
+        views_dir: path.join(paths.baseDir, 'build/public/templates'),
+        version: '2.8.1',
+        isCluster: false,
+        isPrimary: true,
+        jobsDisabled: false,
+    });
+
+    // Explicitly cast as Bool, loader.js passes in isCluster as string 'true'/'false'
+    const castAsBool = ['isCluster', 'isPrimary', 'jobsDisabled'];
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    nconf.stores.env.readOnly = false;
+    castAsBool.forEach((prop) => {
+        const value: string | boolean = nconf.get(prop) as string | boolean;
+        if (value !== undefined) {
+            nconf.set(prop, ['1', 1, 'true', true].includes(value));
+        }
+    });
+
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    nconf.stores.env.readOnly = true;
+    nconf.set('runJobs', nconf.get('isPrimary') && !nconf.get('jobsDisabled'));
+
+    // Ensure themes_path is a full filepath
+    nconf.set('themes_path', path.resolve(paths.baseDir, nconf.get('themes_path') as string));
+    nconf.set('core_templates_path', path.join(paths.baseDir, 'src/views'));
+    nconf.set('base_templates_path', path.join(nconf.get('themes_path') as string, 'nodebb-theme-persona/templates'));
+
+    nconf.set('upload_path', path.resolve(nconf.get('base_dir') as string, nconf.get('upload_path') as string));
+    nconf.set('upload_url', '/assets/uploads');
+
+
+    // nconf defaults, if not set in config
+    if (!nconf.get('sessionKey')) {
+        nconf.set('sessionKey', 'express.sid');
+    }
+
+    if (nconf.get('url')) {
+        const urlFirst: string = nconf.get('url') as string;
+        nconf.set('url', urlFirst.replace(/\/$/, ''));
+        const vals = nconf.get('url') as string;
+        nconf.set('url_parsed', url.parse(vals));
+        // Parse out the relative_url and other goodies from the configured URL
+        const urlObject = url.parse(nconf.get('url') as string);
+        const relativePath = urlObject.pathname !== '/' ? urlObject.pathname.replace(/\/+$/, '') : '';
+        nconf.set('base_url', `${urlObject.protocol}//${urlObject.host}`);
+        nconf.set('secure', urlObject.protocol === 'https:');
+        nconf.set('use_port', !!urlObject.port);
+        nconf.set('relative_path', relativePath);
+        if (!nconf.get('asset_base_url')) {
+            nconf.set('asset_base_url', `${relativePath}/assets`);
+        }
+        nconf.set('port', nconf.get('PORT') as string || nconf.get('port') as string || urlObject.port || (nconf.get('PORT_ENV_VAR') as string ? nconf.get(nconf.get('PORT_ENV_VAR') as string) as string : false) || 4567);
+
+        // cookies don't provide isolation by port: http://stackoverflow.com/a/16328399/122353
+        const domain = nconf.get('cookieDomain') as string || urlObject.hostname;
+        const origins = nconf.get('socket.io:origins') as string || `${urlObject.protocol}//${domain}:*`;
+        nconf.set('socket.io:origins', origins);
+    }
+}
+
+export function versionCheck() {
+    const version = process.version.slice(1);
+    const range = '>=16';
+    const compatible = semver.satisfies(version, range);
+    if (!compatible) {
+        winston.warn('Your version of Node.js is too outdated for NodeBB. Please update your version of Node.js.');
+        winston.warn(`Recommended ${chalk.green(range)}, ${chalk.yellow(version)} provided\n`);
+    }
+}


### PR DESCRIPTION
This pull request finishes the translation of file src/prestart.js from javascript to typescript. This translation has been done in order to gracefully and incrementally move the parent repository to typescript. Keeping in mind that some modules have not been translated to typescript yet, I have used an eslint feature to work with existing modules such that they won't show up in linting errors. This feature can be used by putting this 'eslint-disable-next-line @typescript-eslint/no-unsafe-member-access' in the code. I had made sure that the code complied with all the eslint restrictions and the translated file passed all lining and other tests in the parent repository.